### PR TITLE
Changes to distribution comparison metrics and scatterplot

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -333,9 +333,9 @@ class WorkloadEvaluator:
                     #workload.plot_columns('entropy_mean_prediction', ['entropy_agreement']) 
                     # Generate a custom plot and not use the workload.plot_columns ... 
                     num_plots = len(['entropy_agreement'])
-                    num_rows = 2
+                    num_rows = 1
                     num_cols = math.ceil(num_plots / num_rows)
-                    plt.figure(figsize=(15, 10))
+                    plt.figure(figsize=(8,3.3))
                     ent = 'entropy_mean_prediction'
                     for i, measure in enumerate(['entropy_agreement'], 1):
                         plt.subplot(num_rows, num_cols, i)
@@ -349,9 +349,9 @@ class WorkloadEvaluator:
                             line_kws={'linewidth': 1.5}
                         )
                         correlation = workload.df[measure].corr(workload.df['entropy_mean_prediction'])
-                        plt.title(f'{ent} vs {measure}\nCorrelation = {correlation:.6f}')
-                        plt.xlabel(measure)
-                        plt.ylabel('entropy_mean_prediction')
+                        #plt.title(f'Correlation = {correlation:.6f}')
+                        plt.xlabel(self.mapping_helper[measure])
+                        plt.ylabel(self.mapping_helper['entropy_mean_prediction'])
                         plt.grid(True, linestyle='--', alpha=0.6)
                     plt.tight_layout()
                     #plt.show()


### PR DESCRIPTION
This PR does 2 things:

1. Improve scatterplot (in ``scatter_plot_correlation_user_vs_models_entropy()``) to make it a bit nicer for Overleaf. This involved mainly changing the axes names and changing the figure size.

2. Update the ``calculate_JSD_MSE_CORR()`` function to calculate the mean and standard deviation correctly. Previously, these summary statistics were being calculated over all data samples. With this fix, the mean over all data samples is calculated for each seed independently. Then at the end, the mean and std of the 3 random seeds are saved to the results files.